### PR TITLE
Add Transaction Label Prefix Search and Last Used Tracking Functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -2896,6 +2896,7 @@ export class DojoExpressClient implements DojoClientApi {
         outputs: DojoOutputApi[];
         total: number;
     }> 
+    async getTransactionLabels(options?: DojoGetTransactionLabels, txid?: string): Promise<string[] | undefined> 
     async createTransaction(inputs: Record<string, DojoTxInputsApi>, inputSelection: DojoTxInputSelectionApi | undefined, outputs: DojoCreateTxOutputApi[], outputGeneration?: DojoOutputGenerationApi, feeModel?: DojoFeeModelApi, labels?: string[] | undefined, note?: string | undefined, recipient?: string | undefined): Promise<DojoCreateTransactionResultApi> 
     async processTransaction(rawTx: string | Buffer, reference: string, outputMap: Record<string, number>): Promise<DojoProcessTransactionResultApi> 
     async submitDirectTransaction(protocol: string, transaction: DojoSubmitDirectTransactionApi, senderIdentityKey: string, note: string, labels: string[], derivationPrefix?: string): Promise<DojoSubmitDirectTransactionResultApi> 
@@ -3056,6 +3057,12 @@ async getTotalOfAmounts(direction: "incoming" | "outgoing", options?: DojoGetTot
 
 ```ts
 async getTotalOfUnspentOutputs(basket?: string): Promise<number | undefined> 
+```
+
+##### Class DojoExpressClient Method getTransactionLabels
+
+```ts
+async getTransactionLabels(options?: DojoGetTransactionLabels, txid?: string): Promise<string[] | undefined> 
 ```
 
 ##### Class DojoExpressClient Method getTransactionOutputs

--- a/src/DojoExpressClient.ts
+++ b/src/DojoExpressClient.ts
@@ -8,7 +8,7 @@ import {
   DojoProcessTransactionResultApi, ERR_INVALID_PARAMETER, asString, DojoUserStateApi,
   CwiError, ERR_BAD_REQUEST, DojoSyncApi, DojoSyncOptionsApi, DojoSyncIdentifyParams, DojoSyncIdentifyResultApi,
   DojoSyncUpdateParams, DojoSyncUpdateResultApi, DojoSyncMergeParams, DojoSyncMergeResultApi,
-  restoreUserStateEntities, DojoIdentityApi, SyncDojoConfigBaseApi, validateDate, DojoGetTransactionLabels
+  restoreUserStateEntities, DojoIdentityApi, SyncDojoConfigBaseApi, validateDate, DojoGetTransactionLabelsOptions, DojoTxLabelApi
 } from 'cwi-base'
 
 import { AuthriteClient } from 'authrite-js'
@@ -229,9 +229,9 @@ export class DojoExpressClient implements DojoClientApi {
     return results
   }
 
-  async getTransactionLabels (options?: DojoGetTransactionLabels, txid?: string): Promise<string[] | undefined> {
+  async getTransactionLabels(options?: DojoGetTransactionLabelsOptions): Promise<DojoTxLabelApi[] | undefined> {
     this.verifyAuthenticated()
-    return await this.postJson('/getTransactionLabels', { identityKey: this.identityKey, txid, options })
+    return await this.postJson('/getTransactionLabels', { identityKey: this.identityKey, options })
   }
 
   async createTransaction (

--- a/src/DojoExpressClient.ts
+++ b/src/DojoExpressClient.ts
@@ -229,9 +229,14 @@ export class DojoExpressClient implements DojoClientApi {
     return results
   }
 
-  async getTransactionLabels(options?: DojoGetTransactionLabelsOptions): Promise<DojoTxLabelApi[] | undefined> {
+  async getTransactionLabels(options?: DojoGetTransactionLabelsOptions): Promise<{ labels: DojoTxLabelApi[], total: number }> {
     this.verifyAuthenticated()
-    return await this.postJson('/getTransactionLabels', { identityKey: this.identityKey, options })
+    const results:{ labels: DojoTxLabelApi[], total: number} = await this.postJson('/getTransactionLabels', { identityKey: this.identityKey, options })
+    for (const r of results.labels) {
+      r.created_at = validateDate(r.created_at)
+      r.updated_at = validateDate(r.updated_at)  
+    }
+    return results
   }
 
   async createTransaction (

--- a/src/DojoExpressClient.ts
+++ b/src/DojoExpressClient.ts
@@ -8,7 +8,7 @@ import {
   DojoProcessTransactionResultApi, ERR_INVALID_PARAMETER, asString, DojoUserStateApi,
   CwiError, ERR_BAD_REQUEST, DojoSyncApi, DojoSyncOptionsApi, DojoSyncIdentifyParams, DojoSyncIdentifyResultApi,
   DojoSyncUpdateParams, DojoSyncUpdateResultApi, DojoSyncMergeParams, DojoSyncMergeResultApi,
-  restoreUserStateEntities, DojoIdentityApi, SyncDojoConfigBaseApi, validateDate
+  restoreUserStateEntities, DojoIdentityApi, SyncDojoConfigBaseApi, validateDate, DojoGetTransactionLabels
 } from 'cwi-base'
 
 import { AuthriteClient } from 'authrite-js'
@@ -227,6 +227,11 @@ export class DojoExpressClient implements DojoClientApi {
       r.updated_at = validateDate(r.updated_at)  
     }
     return results
+  }
+
+  async getTransactionLabels (options?: DojoGetTransactionLabels, txid?: string): Promise<string[] | undefined> {
+    this.verifyAuthenticated()
+    return await this.postJson('/getTransactionLabels', { identityKey: this.identityKey, txid, options })
   }
 
   async createTransaction (


### PR DESCRIPTION
implemented user transaction label prefix search and last-used tracking allowing users to query labels in either ascending or descending order